### PR TITLE
Suggested changes to draft-rpki-communities-harmful

### DIFF
--- a/draft-ietf-sidrops-avoid-rpki-state-in-bgp.xml
+++ b/draft-ietf-sidrops-avoid-rpki-state-in-bgp.xml
@@ -131,7 +131,7 @@ https://mailarchive.ietf.org/arch/msg/sidrops/YV1WfoxQNiwfOjtKIY1d6YJjRxM/
       <section title="ROA Issuance" anchor="outage-roa-issuance">
         <t>
           Large-Scale ROA issuance should be a comparatively rare event for individual networks.
-          However, several cases exist where issuance by individual operators or (malicious) coordinated issuance of ROAs by multiple operators may lead to a high churn triggering a continuous flow of BGP Update messages caused by operators using transitive BGP attributes to signal RPKI Validation State.
+          However, several cases exist where issuance by individual operators or (malicious) coordinated issuance of ROAs by multiple operators may lead to a high route churn triggering a continuous flow of BGP Update messages caused by operators using transitive BGP attributes to signal RPKI Validation State.
         </t>
         <t>
           Specifically:
@@ -152,7 +152,7 @@ https://mailarchive.ietf.org/arch/msg/sidrops/YV1WfoxQNiwfOjtKIY1d6YJjRxM/
       <section title="ROA Revocation" anchor="outage-roa-revocation">
         <t>
           Large-Scale ROA revocation should be a comparatively rare event for individual networks.
-          However, several cases exist where revocations by individual operators or (malicious) coordinated revocation of ROAs by multiple operators may lead to a high churn triggering a continuous flow of BGP Update messages caused by operators using transitive BGP attributes to signal RPKI Validation State.
+          However, several cases exist where revocations by individual operators or (malicious) coordinated revocation of ROAs by multiple operators may lead to a high route churn triggering a continuous flow of BGP Update messages caused by operators using transitive BGP attributes to signal RPKI Validation State.
         </t>
         <t>
           Specifically:
@@ -341,7 +341,7 @@ https://mailarchive.ietf.org/arch/msg/sidrops/YV1WfoxQNiwfOjtKIY1d6YJjRxM/
   <section title="Security Considerations">
     <t>
       The use of transitive attributes to signal RPKI Validation State may enable attackers to cause notable route churn by issuing and withdrawing, e.g., ROAs for their prefixes.
-      DFZ routers may not be equipped to handle churn in all directions at global scale, especially if said churn cascades or repeats periodically.
+      DFZ routers may not be equipped to handle route churn in all directions at global scale, especially if said route churn cascades or repeats periodically.
     </t>
     <t>
       To prevent the aforementioned issue, operators <bcp14>SHOULD NOT</bcp14> signal Validation State to neighbors through BGP path attributes.

--- a/draft-ietf-sidrops-avoid-rpki-state-in-bgp.xml
+++ b/draft-ietf-sidrops-avoid-rpki-state-in-bgp.xml
@@ -351,7 +351,10 @@ https://mailarchive.ietf.org/arch/msg/sidrops/YV1WfoxQNiwfOjtKIY1d6YJjRxM/
     </t>
     <t>
       DFZ routers may not be equipped to handle route churn in all directions at global scale, especially if said route churn cascades, persists, or repeats periodically.
-      To prevent global route churn, operators <bcp14>SHOULD NOT</bcp14> signal Validation State to eBGP neighbors through BGP path attributes.
+      To prevent global route churn, operators <bcp14>SHOULD NOT</bcp14> signal RPKI Validation State to eBGP neighbors through transitive BGP path attributes.
+	  If an operator is dependent on signaling RPKI Validation State among BGP speakers within their AS, they <bcp14>SHOULD</bcp14> ensure that these attributes are removed before announcing NLRI to eBGP neighbors.
+    </t>
+    <t>
       Furthermore, operators <bcp14>SHOULD</bcp14> consider transitive attributes on NLRI imported from eBGP neighbors to be harmful.
 	  Therefore, operators <bcp14>SHOULD</bcp14> remove values used to signal RPKI Validation State when importing NLRI with an idempotent operation until the corresponding neighbor follows guidance in this document as well.
       <!-- Clarified what 'not accept' means here;

--- a/draft-ietf-sidrops-avoid-rpki-state-in-bgp.xml
+++ b/draft-ietf-sidrops-avoid-rpki-state-in-bgp.xml
@@ -114,7 +114,7 @@ https://mailarchive.ietf.org/arch/msg/sidrops/YV1WfoxQNiwfOjtKIY1d6YJjRxM/
     <t>
     </t>
       The guidance in this document applies to all current and future transitive BGP attributes that may be implicitly or explicitly used to signal Validation State to neighbors.
-      Similarly, this applies to non-ROA validation mechanics based on RPKI, e.g., ASPA <xref target="I-D.ietf-sidrops-aspa-profile"/>, BGPSec <xref target="RFC8205"/>, and any other future validation mechanic build upon the RPKI.
+      Similarly, this guidance also applies to non-ROA validation mechanics based on RPKI, e.g., ASPA <xref target="I-D.ietf-sidrops-aspa-profile"/>, BGPSec <xref target="RFC8205"/>, and any other future validation mechanic build upon the RPKI.
     </t>
   </section>
 

--- a/draft-ietf-sidrops-avoid-rpki-state-in-bgp.xml
+++ b/draft-ietf-sidrops-avoid-rpki-state-in-bgp.xml
@@ -94,6 +94,7 @@ https://mailarchive.ietf.org/arch/msg/sidrops/YV1WfoxQNiwfOjtKIY1d6YJjRxM/
     <t>
       Hence, this document provides guidance to avoid carrying RPKI-derived Validation States in Transitive Border Gateway Protocol (BGP) Path Attributes <xref target="RFC4271" section="5"/>.
       Specifically, Operators <bcp14>SHOULD NOT</bcp14> group BGP routes by their Prefix Origin Validation state <xref target="RFC6811"/> into distinct BGP Communities <xref target="RFC1997"/> <xref target="RFC8092"/>.
+      If local technical requirements or the implementation used by an operator necessitates the use of transitive attributes to signal RPKI Validation State, the operator <bcp14>SHOULD</bcp14> ensure that these attributes are removed in NLRI announced to eBGP neighbors.
       Avoiding the use of BGP Communities to signal RPKI Validation States prevents BGP UPDATE messages from being needlessly flooded into the global Internet routing system.
     </t>
 
@@ -109,12 +110,16 @@ https://mailarchive.ietf.org/arch/msg/sidrops/YV1WfoxQNiwfOjtKIY1d6YJjRxM/
 
   <section title="Scope" anchor="scope">
     <t>
-      This document discusses signaling locally significant RPKI Validation States to BGP neighbors through transitive BGP attributes.
+      This document discusses signaling locally significant RPKI Validation States to external BGP neighbors through transitive BGP attributes.
       This includes operator-specific BGP Communities to signal Validation States, as well as any current or future standardized well-known BGP Communities denoting Validation State (for example as specified for Extended BGP Communities in <xref target="RFC8097"/>).
     <t>
     </t>
       The guidance in this document applies to all current and future transitive BGP attributes that may be implicitly or explicitly used to signal Validation State to neighbors.
       Similarly, this applies to non-ROA validation mechanics based on RPKI, e.g., ASPA <xref target="I-D.ietf-sidrops-aspa-profile"/>, BGPSec <xref target="RFC8205"/>, and any other future validation mechanic build upon the RPKI.
+    </t>
+    <t>
+      The document acknowleges that specific operational requirements, e.g., a used implementation still being dependent on it, may necessitate the use of transitive BGP path attributes to signal RPKI Validation State.
+      If this is the case, the dependent operator <bcp14>SHOULD</bcp14> ensure that these attributes are removed before announcing NLRI to eBGP neighbors.
     </t>
   </section>
 

--- a/draft-ietf-sidrops-avoid-rpki-state-in-bgp.xml
+++ b/draft-ietf-sidrops-avoid-rpki-state-in-bgp.xml
@@ -111,8 +111,8 @@ https://mailarchive.ietf.org/arch/msg/sidrops/YV1WfoxQNiwfOjtKIY1d6YJjRxM/
     <t>
       This document discusses signaling locally significant RPKI Validation States to BGP neighbors through transitive BGP attributes.
       This includes operator-specific BGP Communities to signal Validation States, as well as any current or future standardized well-known BGP Communities denoting Validation State (for example as specified for Extended BGP Communities in <xref target="RFC8097"/>).
-    <t>
     </t>
+    <t>
       The guidance in this document applies to all current and future transitive BGP attributes that may be implicitly or explicitly used to signal Validation State to neighbors.
       Similarly, this applies to non-ROA validation mechanics based on RPKI, e.g., ASPA <xref target="I-D.ietf-sidrops-aspa-profile"/>, BGPSec <xref target="RFC8205"/>, and any other future validation mechanic build upon the RPKI.
     </t>

--- a/draft-ietf-sidrops-avoid-rpki-state-in-bgp.xml
+++ b/draft-ietf-sidrops-avoid-rpki-state-in-bgp.xml
@@ -351,8 +351,8 @@ https://mailarchive.ietf.org/arch/msg/sidrops/YV1WfoxQNiwfOjtKIY1d6YJjRxM/
     </t>
     <t>
       DFZ routers may not be equipped to handle route churn in all directions at global scale, especially if said route churn cascades, persists, or repeats periodically.
-      To prevent global route churn, operators <bcp14>SHOULD NOT</bcp14> signal Validation State to neighbors through BGP path attributes.
-      Furthermore, operators <bcp14>SHOULD</bcp14> consider transitive attributes on imported NLRI to be harmful.
+      To prevent global route churn, operators <bcp14>SHOULD NOT</bcp14> signal Validation State to eBGP neighbors through BGP path attributes.
+      Furthermore, operators <bcp14>SHOULD</bcp14> consider transitive attributes on NLRI imported from eBGP neighbors to be harmful.
 	  Therefore, operators <bcp14>SHOULD</bcp14> remove values used to signal RPKI Validation State when importing NLRI with an idempotent operation until the corresponding neighbor follows guidance in this document as well.
       <!-- Clarified what 'not accept' means here;
            Still, this mildly collides with the 'do not touch' guidance in the bgp-opsec-upd draft.

--- a/draft-ietf-sidrops-avoid-rpki-state-in-bgp.xml
+++ b/draft-ietf-sidrops-avoid-rpki-state-in-bgp.xml
@@ -346,7 +346,7 @@ https://mailarchive.ietf.org/arch/msg/sidrops/YV1WfoxQNiwfOjtKIY1d6YJjRxM/
   <section title="Security Considerations">
     <t>
       BGP is not guranteed to converge, and RPKI lacks strict consistency, and is instead only eventually consistent.
-      External validation state anotated in a received NLRI may either depend on a less current view on the RPKI than the one in local scope, or the NLRI may be several hours old itself.
+      External validation state anotated in a received NLRI may either depend on a less current view on the RPKI than the one in the local administrative domain, or the NLRI may be several hours old itself.
       Hence, the Validation State of a received announcement can only have local scope.
     </t>
     <t>

--- a/draft-ietf-sidrops-avoid-rpki-state-in-bgp.xml
+++ b/draft-ietf-sidrops-avoid-rpki-state-in-bgp.xml
@@ -345,8 +345,8 @@ https://mailarchive.ietf.org/arch/msg/sidrops/YV1WfoxQNiwfOjtKIY1d6YJjRxM/
 
   <section title="Security Considerations">
     <t>
-      BGP is not guranteed to converge, and RPKI lacks strict consistency, and is instead only eventually consistent.
-      External validation state anotated in a received NLRI may either depend on a less current view on the RPKI than the one in the local administrative domain, or the NLRI may be several hours old itself.
+      BGP is not guranteed to converge, and the view on the RPKI within an individual administrative domain is only eventually consistent.
+      External validation state anotated in a received NLRI may either depend on a different view on the RPKI than the one in the local administrative domain, or the NLRI may be several hours old itself.
       Hence, the Validation State of a received announcement can only have local scope.
     </t>
     <t>

--- a/draft-ietf-sidrops-avoid-rpki-state-in-bgp.xml
+++ b/draft-ietf-sidrops-avoid-rpki-state-in-bgp.xml
@@ -71,7 +71,7 @@ https://mailarchive.ietf.org/arch/msg/sidrops/YV1WfoxQNiwfOjtKIY1d6YJjRxM/
     </t>
     <t>
       Operators <bcp14>SHOULD</bcp14> ensure Validation States are not signaled in transitive BGP Path Attributes.
-      Specifically, Operators <bcp14>SHOULD NOT</bcp14> group BGP routes by their Prefix Origin Validation state into distinct BGP Communities.
+      Specifically, Operators <bcp14>SHOULD NOT</bcp14> group BGP routes by their Prefix Origin Validation state into BGP Communities.
     </t>
   </abstract>
   
@@ -83,17 +83,17 @@ https://mailarchive.ietf.org/arch/msg/sidrops/YV1WfoxQNiwfOjtKIY1d6YJjRxM/
 
     <t>
       The Resource Public Key Infrastructure (RPKI) <xref target="RFC6480"/> allows for validating received BGP routes, e.g., their Route Origin Validation (ROV) state.
-      In the past some operators and vendors suggested to use distinct BGP Communities <xref target="RFC1997"/> <xref target="RFC8092"/> to annotate received routes with the local Validation State.
+      In the past some operators and vendors suggested to use BGP Communities <xref target="RFC1997"/> <xref target="RFC8092"/> to annotate received routes with the local Validation State.
       Some claim that the practice of signaling Validation States could be useful, for example to IBGP speakers, in order to avoid each IBGP speaker having to perform their own route origin validation.
     </t>
     <t>
-      However, annotating a route with a distinct transitive attribute (based on the Validation State) means that BGP update messages have to be send to every neighbor when the Validation State changes.
+      However, annotating a route with a transitive attribute (based on the Validation State) means that BGP update messages have to be send to every neighbor when the Validation State changes.
       This means that when for example Route Origin Authorizations <xref target="RFC9582"/> are issued, or are revoked, or RPKI-To-Router <xref target="RFC8210"/> sessions are terminated, new BGP UPDATE messages will have to be sent for all routes that were previously annotated with a BGP Community associated with a different Validation State.
       Furthermore, given that BGP Communities are a transitive attribute, such a BGP UPDATE might end up propagating through large portions of the Default-Free Zone (DFZ).
     </t>
     <t>
       Hence, this document provides guidance to avoid carrying RPKI-derived Validation States in Transitive Border Gateway Protocol (BGP) Path Attributes <xref target="RFC4271" section="5"/>.
-      Specifically, Operators <bcp14>SHOULD NOT</bcp14> group BGP routes by their Prefix Origin Validation state <xref target="RFC6811"/> into distinct BGP Communities <xref target="RFC1997"/> <xref target="RFC8092"/>.
+      Specifically, Operators <bcp14>SHOULD NOT</bcp14> group BGP routes by their Prefix Origin Validation state <xref target="RFC6811"/> into BGP Communities <xref target="RFC1997"/> <xref target="RFC8092"/>.
       Avoiding the use of BGP Communities to signal RPKI Validation States prevents BGP UPDATE messages from being needlessly flooded into the global Internet routing system.
     </t>
 

--- a/draft-ietf-sidrops-avoid-rpki-state-in-bgp.xml
+++ b/draft-ietf-sidrops-avoid-rpki-state-in-bgp.xml
@@ -118,7 +118,7 @@ https://mailarchive.ietf.org/arch/msg/sidrops/YV1WfoxQNiwfOjtKIY1d6YJjRxM/
       Similarly, this guidance also applies to non-ROA validation mechanics based on RPKI, e.g., ASPA <xref target="I-D.ietf-sidrops-aspa-profile"/>, BGPSec <xref target="RFC8205"/>, and any other future validation mechanic build upon the RPKI.
     </t>
     <t>
-      The document acknowleges that specific operational requirements, e.g., a used implementation still being dependent on it, may necessitate the use of transitive BGP path attributes to signal RPKI Validation State.
+      The document acknowleges that specific operational requirements, e.g., a BGP implementation used by an operator still being dependent on annotating RPKI Validation State using BGP attributes, may necessitate the use of BGP path attributes to signal RPKI Validation State.
       If this is the case, the dependent operator <bcp14>SHOULD</bcp14> ensure that these attributes are removed before announcing NLRI to EBGP neighbors.
     </t>
   </section>

--- a/draft-ietf-sidrops-avoid-rpki-state-in-bgp.xml
+++ b/draft-ietf-sidrops-avoid-rpki-state-in-bgp.xml
@@ -340,14 +340,24 @@ https://mailarchive.ietf.org/arch/msg/sidrops/YV1WfoxQNiwfOjtKIY1d6YJjRxM/
 
   <section title="Security Considerations">
     <t>
-      The use of transitive attributes to signal RPKI Validation State may enable attackers to cause notable route churn by issuing and withdrawing, e.g., ROAs for their prefixes.
-      DFZ routers may not be equipped to handle churn in all directions at global scale, especially if said churn cascades or repeats periodically.
+      BGP is not guranteed to converge, and RPKI lacks strict consistency, and is instead only eventually consistent.
+      External validation state anotated in a received NLRI may either depend on a less current view on the RPKI than the one in local scope, or the NLRI may be several hours old itself.
+      Hence, the Validation State of a received announcement can only have local scope.
     </t>
     <t>
-      To prevent the aforementioned issue, operators <bcp14>SHOULD NOT</bcp14> signal Validation State to neighbors through BGP path attributes.
-      Furthermore, Validation State signaling <bcp14>SHOULD NOT</bcp14> be accepted from a neighbor AS.
-      Instead, the Validation State of a received announcement has only local scope due to issues such as scope of trust and RPKI synchrony.
-      <!-- synchrony here is meant to refer to the global RPKI eventually being consistent, a Validation State in a BGP community might be hours old -->
+      Additionally, the use of transitive attributes to signal RPKI Validation State may enable attackers to cause notable route churn.
+      This can be accomplished by an attacker issuing and withdrawing, e.g., ROAs for their prefixes, or by the attacker continuously altering transitive attributes used to signal RPKI Validation State for NLRI they readvertise.
+      The latter is possible as NLRI carry no information allowing an ingesting party to validate the integrity of transitive BGP attributes.
+    </t>
+    <t>
+      DFZ routers may not be equipped to handle route churn in all directions at global scale, especially if said route churn cascades, persists, or repeats periodically.
+      To prevent global route churn, operators <bcp14>SHOULD NOT</bcp14> signal Validation State to neighbors through BGP path attributes.
+      Furthermore, operators <bcp14>SHOULD</bcp14> consider transitive attributes on imported NLRI to be harmful.
+	  Therefore, operators <bcp14>SHOULD</bcp14> remove values used to signal RPKI Validation State when importing NLRI with an idempotent operation until the corresponding neighbor follows guidance in this document as well.
+      <!-- Clarified what 'not accept' means here;
+           Still, this mildly collides with the 'do not touch' guidance in the bgp-opsec-upd draft.
+           Given the formulation there, though, I believe that the above would be sensible guidance, i.e., remove those attributes.
+           Not sure whether it is necessary to specify idempotency.-->
     </t>
   </section>
 

--- a/draft-ietf-sidrops-avoid-rpki-state-in-bgp.xml
+++ b/draft-ietf-sidrops-avoid-rpki-state-in-bgp.xml
@@ -360,8 +360,7 @@ https://mailarchive.ietf.org/arch/msg/sidrops/YV1WfoxQNiwfOjtKIY1d6YJjRxM/
       If an operator is dependent on signaling RPKI Validation State among BGP speakers within their AS, they <bcp14>SHOULD</bcp14> ensure that these attributes are removed before announcing NLRI to EBGP neighbors.
     </t>
     <t>
-      Furthermore, operators <bcp14>SHOULD</bcp14> consider transitive attributes on NLRI imported from EBGP neighbors to be harmful.
-      Therefore, operators <bcp14>SHOULD</bcp14> remove values used to signal RPKI Validation State when importing NLRI with an idempotent operation until the corresponding neighbor follows guidance in this document as well.
+      Given their potential negative impact, operators <bcp14>SHOULD</bcp14> remove attributes used to signal RPKI Validation State when importing NLRI with an idempotent operation until the corresponding neighbor follows guidance in this document as well.
       <!-- Clarified what 'not accept' means here;
            Still, this mildly collides with the 'do not touch' guidance in the bgp-opsec-upd draft.
            Given the formulation there, though, I believe that the above would be sensible guidance, i.e., remove those attributes.

--- a/draft-ietf-sidrops-avoid-rpki-state-in-bgp.xml
+++ b/draft-ietf-sidrops-avoid-rpki-state-in-bgp.xml
@@ -94,7 +94,7 @@ https://mailarchive.ietf.org/arch/msg/sidrops/YV1WfoxQNiwfOjtKIY1d6YJjRxM/
     <t>
       Hence, this document provides guidance to avoid carrying RPKI-derived Validation States in Transitive Border Gateway Protocol (BGP) Path Attributes <xref target="RFC4271" section="5"/>.
       Specifically, operators <bcp14>SHOULD NOT</bcp14> group BGP routes by their Prefix Origin Validation state <xref target="RFC6811"/> into BGP Communities <xref target="RFC1997"/> <xref target="RFC8092"/>.
-      If local technical requirements or the implementation used by an operator necessitates the use of transitive attributes to signal RPKI Validation State, the operator <bcp14>SHOULD</bcp14> ensure that these attributes are removed in NLRI announced to eBGP neighbors.
+      If local technical requirements or the implementation used by an operator necessitates the use of transitive attributes to signal RPKI Validation State, the operator <bcp14>SHOULD</bcp14> ensure that these attributes are removed in NLRI announced to EBGP neighbors.
       Avoiding the use of BGP Communities to signal RPKI Validation States prevents BGP UPDATE messages from being needlessly flooded into the global Internet routing system.
     </t>
 
@@ -119,7 +119,7 @@ https://mailarchive.ietf.org/arch/msg/sidrops/YV1WfoxQNiwfOjtKIY1d6YJjRxM/
     </t>
     <t>
       The document acknowleges that specific operational requirements, e.g., a used implementation still being dependent on it, may necessitate the use of transitive BGP path attributes to signal RPKI Validation State.
-      If this is the case, the dependent operator <bcp14>SHOULD</bcp14> ensure that these attributes are removed before announcing NLRI to eBGP neighbors.
+      If this is the case, the dependent operator <bcp14>SHOULD</bcp14> ensure that these attributes are removed before announcing NLRI to EBGP neighbors.
     </t>
   </section>
 
@@ -356,11 +356,11 @@ https://mailarchive.ietf.org/arch/msg/sidrops/YV1WfoxQNiwfOjtKIY1d6YJjRxM/
     </t>
     <t>
       DFZ routers may not be equipped to handle route churn in all directions at global scale, especially if said route churn cascades, persists, or repeats periodically.
-      To prevent global route churn, operators <bcp14>SHOULD NOT</bcp14> signal RPKI Validation State to eBGP neighbors through transitive BGP path attributes.
-      If an operator is dependent on signaling RPKI Validation State among BGP speakers within their AS, they <bcp14>SHOULD</bcp14> ensure that these attributes are removed before announcing NLRI to eBGP neighbors.
+      To prevent global route churn, operators <bcp14>SHOULD NOT</bcp14> signal RPKI Validation State to EBGP neighbors through transitive BGP path attributes.
+      If an operator is dependent on signaling RPKI Validation State among BGP speakers within their AS, they <bcp14>SHOULD</bcp14> ensure that these attributes are removed before announcing NLRI to EBGP neighbors.
     </t>
     <t>
-      Furthermore, operators <bcp14>SHOULD</bcp14> consider transitive attributes on NLRI imported from eBGP neighbors to be harmful.
+      Furthermore, operators <bcp14>SHOULD</bcp14> consider transitive attributes on NLRI imported from EBGP neighbors to be harmful.
       Therefore, operators <bcp14>SHOULD</bcp14> remove values used to signal RPKI Validation State when importing NLRI with an idempotent operation until the corresponding neighbor follows guidance in this document as well.
       <!-- Clarified what 'not accept' means here;
            Still, this mildly collides with the 'do not touch' guidance in the bgp-opsec-upd draft.


### PR DESCRIPTION
This pull request aggregates several individual proposed changes:

- Fixed syntactic typo: https://github.com/ichdasich/draft-rpki-communities-harmful/tree/fix_typo
- Removal of 'distinct'  in front of BGP communities to ensure text also covers non-distinct, i.e., aggregate BGP communities where validation state is one of the possible factors contributing to the grouping: https://github.com/ichdasich/draft-rpki-communities-harmful/tree/remove_distinct
- Clarified case of operators being dependent on signaling using transitive attributes in iBGP; Clarified that the responsibility to remove the attribute before announcing NLRI in eBGP rests with the dependent operator (following a comment by Ben Maddison from IETF119): https://github.com/ichdasich/draft-rpki-communities-harmful/tree/ebgb_specific_wording
- Expanded and clarified security considerations; Changed flow of the associated section to an incremental reasoning structure: https://github.com/ichdasich/draft-rpki-communities-harmful/tree/clarification_security_considerations
- Expanded a 'this' in the scope section to improve text flow: https://github.com/ichdasich/draft-rpki-communities-harmful/tree/clarification_scope
- Clarified 'churn' to mean 'route churn' throughout the document: https://github.com/ichdasich/draft-rpki-communities-harmful/tree/clarification_churn

The most important (and likely discussion worthy) change content wise is the change to separate eBGP and iBGP and explicitly place responsibility for attribute removal on operators dependent on signalling internally.