### PR TITLE
Strenghten the reco

### DIFF
--- a/draft-ietf-sidrops-avoid-rpki-state-in-bgp.xml
+++ b/draft-ietf-sidrops-avoid-rpki-state-in-bgp.xml
@@ -96,8 +96,8 @@ https://mailarchive.ietf.org/arch/msg/sidrops/YV1WfoxQNiwfOjtKIY1d6YJjRxM/
       Furthermore, given that BGP Communities are a transitive attribute, such a BGP UPDATE might end up propagating through large portions of the Default-Free Zone (DFZ).
     </t>
     <t>
-      Hence, this document provides guidance to avoid carrying RPKI-derived validation states in transitive Border Gateway Protocol (BGP) Path Attributes (<xref target="RFC4271" section="5"/>).
-      Specifically, Operators <bcp14>SHOULD NOT</bcp14> associate BGP Prefix Origin Validation results <xref target="RFC6811"/> with BGP routes using transitive BGP Communities (<xref target="RFC1997"/>, <xref target="RFC4360"/>, <xref target="RFC8092"/>).
+      Hence, this document provides guidance (<xref target="guidance"/>) to avoid carrying RPKI-derived validation states in transitive Border Gateway Protocol (BGP) Path Attributes (<xref target="RFC4271" section="5"/>).
+      Specifically, Operators should not associate BGP Prefix Origin Validation results <xref target="RFC6811"/> with BGP routes using transitive BGP Communities (<xref target="RFC1997"/>, <xref target="RFC4360"/>, <xref target="RFC8092"/>).      
       Furthermore, this document contains data on the measured current impact of BGP Communities used to signal validation states.
     </t>
     <t>
@@ -347,7 +347,7 @@ https://mailarchive.ietf.org/arch/msg/sidrops/YV1WfoxQNiwfOjtKIY1d6YJjRxM/
     </t>
     <t>
       The document acknowledges that specific operational requirements, such as a BGP implementation used by an operator still being dependent on annotating RPKI-derived validation states using BGP attributes, may necessitate the use of BGP path attributes to signal validation states between BGP speakers.
-      If this is the case, the dependent operator <bcp14>SHOULD</bcp14> ensure that these attributes are removed before announcing NLRI to EBGP neighbors.
+      If this is the case, the dependent operator <bcp14>MUST</bcp14> ensure that these attributes are removed before announcing NLRI to EBGP neighbors.
       Depending on the supported functionality of the BGP implementations in use in a given AS, removal of the aforementioned attributes may not be consistently possible across the AS, leading to the conditions this document is intended to discuss.
     </t>
   </section>


### PR DESCRIPTION
Compliance with thee BCP will be hard to assess as there is no mandatory recommendation. I suggest to upgrade one of the main recos.

Also, added a pointer to where the reco is provided + avoid redundant language.