### PR TITLE
added gitignore to prevent accidentally adding result files to commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Files after make
+draft-ietf-sidrops-avoid-rpki-state-in-bgp.html
+draft-ietf-sidrops-avoid-rpki-state-in-bgp.txt
+
+# vim swp files
+*.swp
+
+# "some other editor" swap files
+*~


### PR DESCRIPTION
This PR introduces a `.gitignore` file to ensure no temporary files are accidentally added to the repository.