### PR TITLE
Tf 2026 06 04 relationship to 8097

### DIFF
--- a/draft-ietf-sidrops-avoid-rpki-state-in-bgp.xml
+++ b/draft-ietf-sidrops-avoid-rpki-state-in-bgp.xml
@@ -129,6 +129,17 @@ https://mailarchive.ietf.org/arch/msg/sidrops/YV1WfoxQNiwfOjtKIY1d6YJjRxM/
       The guidance in this document applies to all current and future BGP Path Attributes that may be implicitly or explicitly used to signal validation states to EBGP neighbors.
       Similarly, this guidance also applies to non-ROA validation mechanics based on RPKI; e.g., Autonomous System Provider Authorization (ASPA) <xref target="I-D.ietf-sidrops-aspa-profile"/>, BGPsec <xref target="RFC8205"/>, and any other future validation mechanic built upon the RPKI.
     </t>
+    <t>
+      <xref format="default" pageno="false" target="RFC8097"/> introduces an extended community for use in iBGP and selected eBGP scenarios, providing normative guidance on implementations' behavior if support for this feature is explicitly configured.
+      This document does not provide normative guidance regarding implementation behavavior, i.e., regarding the support for the extended community for signalling validation state described in  <xref format="default" pageno="false" target="RFC8097"/>.
+      Instead, guidance in this document is normative regarding operators' use of this feature.
+    </t>
+    <t>
+      In addition to implementation guidance in <xref format="default" pageno="false" target="RFC8097"/>, the document also provides non-normative text on possible deployment scenarios where RPKI validation state might be signalled to eBGP speakers.
+      In that regard, this documment updates <xref format="default" pageno="false" target="RFC8097"/>, adding normative language that these implementation are <bcp14>NOT RECOMMENDED</bcp14>.
+      Operators <bcp14>MAY</bcp14> opt to deploy such configurations in restricted environments, e.g., when using multiple ASNs in a single administrative domain;
+      Nevertheless, operators are encouraged to take care and precautions to mitigate the risks described in this document when choosing to implement these scenarios.
+    </t>
   </section>
 
   <section title="Risks of Signaling Validation State Transitively to EBGP Neighbors" anchor="signaling-risks">
@@ -431,6 +442,7 @@ https://mailarchive.ietf.org/arch/msg/sidrops/YV1WfoxQNiwfOjtKIY1d6YJjRxM/
     <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.6480.xml"/>
     <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.6811.xml"/>
     <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.8092.xml"/>
+    <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.8097.xml"/>
     <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.8174.xml"/>
     <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.8210.xml"/>
   </references>

--- a/draft-ietf-sidrops-avoid-rpki-state-in-bgp.xml
+++ b/draft-ietf-sidrops-avoid-rpki-state-in-bgp.xml
@@ -132,12 +132,12 @@ https://mailarchive.ietf.org/arch/msg/sidrops/YV1WfoxQNiwfOjtKIY1d6YJjRxM/
       Similarly, this guidance also applies to non-ROA validation mechanics based on RPKI; e.g., Autonomous System Provider Authorization (ASPA) <xref target="I-D.ietf-sidrops-aspa-profile"/>, BGPsec <xref target="RFC8205"/>, and any other future validation mechanic built upon the RPKI.
     </t>
     <t>
-      <xref format="default" pageno="false" target="RFC8097"/> introduces an extended community for use in iBGP and selected eBGP scenarios, providing normative guidance on implementations' behavior if and only if support for this feature is explicitly configured.
+      <xref format="default" pageno="false" target="RFC8097"/> introduces an extended community for use in IBGP and selected EBGP scenarios, providing normative guidance on implementations' behavior if and only if support for this feature is explicitly configured.
       This document does not provide normative guidance regarding implementation behavavior, i.e., regarding the support for the extended community for signaling validation state described in  <xref format="default" pageno="false" target="RFC8097"/>.
       Instead, guidance in this document is normative regarding operators' use of this feature.
     </t>
     <t>
-      In addition to implementation guidance in <xref format="default" pageno="false" target="RFC8097"/>, the document also provides non-normative text on possible deployment scenarios where RPKI validation state might be signalled to eBGP speakers.
+      In addition to implementation guidance in <xref format="default" pageno="false" target="RFC8097"/>, the document also provides non-normative text on possible deployment scenarios where RPKI-derived state might be signaled to EBGP speakers.
       In that regard, this documment updates <xref format="default" pageno="false" target="RFC8097"/>, adding normative language that these implementation are <bcp14>NOT RECOMMENDED</bcp14>.
       Operators <bcp14>MAY</bcp14> opt to deploy such configurations in restricted environments, e.g., when using multiple ASNs in a single administrative domain;
       Nevertheless, operators are encouraged to take care and precautions to mitigate the risks described in this document when choosing to implement these scenarios.

--- a/draft-ietf-sidrops-avoid-rpki-state-in-bgp.xml
+++ b/draft-ietf-sidrops-avoid-rpki-state-in-bgp.xml
@@ -133,7 +133,7 @@ https://mailarchive.ietf.org/arch/msg/sidrops/YV1WfoxQNiwfOjtKIY1d6YJjRxM/
     </t>
     <t>
       <xref format="default" pageno="false" target="RFC8097"/> introduces an extended community for use in iBGP and selected eBGP scenarios, providing normative guidance on implementations' behavior if and only if support for this feature is explicitly configured.
-      This document does not provide normative guidance regarding implementation behavavior, i.e., regarding the support for the extended community for signalling validation state described in  <xref format="default" pageno="false" target="RFC8097"/>.
+      This document does not provide normative guidance regarding implementation behavavior, i.e., regarding the support for the extended community for signaling validation state described in  <xref format="default" pageno="false" target="RFC8097"/>.
       Instead, guidance in this document is normative regarding operators' use of this feature.
     </t>
     <t>

--- a/draft-ietf-sidrops-avoid-rpki-state-in-bgp.xml
+++ b/draft-ietf-sidrops-avoid-rpki-state-in-bgp.xml
@@ -139,7 +139,7 @@ https://mailarchive.ietf.org/arch/msg/sidrops/YV1WfoxQNiwfOjtKIY1d6YJjRxM/
     <t>
       In addition to implementation guidance in <xref format="default" pageno="false" target="RFC8097"/>, the document also provides non-normative text on possible deployment scenarios where RPKI-derived state might be signaled to EBGP speakers.
       In that regard, this documment updates <xref format="default" pageno="false" target="RFC8097"/>, adding normative language that these deployment scenarios are <bcp14>NOT RECOMMENDED</bcp14>.
-      Operators <bcp14>MAY</bcp14> opt to deploy such configurations in restricted environments, e.g., when using multiple ASNs in a single administrative domain;
+      Operators <bcp14>MAY</bcp14> opt to deploy such configurations in restricted environments, e.g., when using multiple ASes in a single administrative domain;
       Nevertheless, operators are encouraged to take care and precautions to mitigate the risks described in this document when choosing to implement these scenarios.
     </t>
   </section>

--- a/draft-ietf-sidrops-avoid-rpki-state-in-bgp.xml
+++ b/draft-ietf-sidrops-avoid-rpki-state-in-bgp.xml
@@ -138,7 +138,7 @@ https://mailarchive.ietf.org/arch/msg/sidrops/YV1WfoxQNiwfOjtKIY1d6YJjRxM/
     </t>
     <t>
       In addition to implementation guidance in <xref format="default" pageno="false" target="RFC8097"/>, the document also provides non-normative text on possible deployment scenarios where RPKI-derived state might be signaled to EBGP speakers.
-      In that regard, this documment updates <xref format="default" pageno="false" target="RFC8097"/>, adding normative language that these implementation are <bcp14>NOT RECOMMENDED</bcp14>.
+      In that regard, this documment updates <xref format="default" pageno="false" target="RFC8097"/>, adding normative language that these deployment scenarios are <bcp14>NOT RECOMMENDED</bcp14>.
       Operators <bcp14>MAY</bcp14> opt to deploy such configurations in restricted environments, e.g., when using multiple ASNs in a single administrative domain;
       Nevertheless, operators are encouraged to take care and precautions to mitigate the risks described in this document when choosing to implement these scenarios.
     </t>

--- a/draft-ietf-sidrops-avoid-rpki-state-in-bgp.xml
+++ b/draft-ietf-sidrops-avoid-rpki-state-in-bgp.xml
@@ -132,7 +132,7 @@ https://mailarchive.ietf.org/arch/msg/sidrops/YV1WfoxQNiwfOjtKIY1d6YJjRxM/
       Similarly, this guidance also applies to non-ROA validation mechanics based on RPKI; e.g., Autonomous System Provider Authorization (ASPA) <xref target="I-D.ietf-sidrops-aspa-profile"/>, BGPsec <xref target="RFC8205"/>, and any other future validation mechanic built upon the RPKI.
     </t>
     <t>
-      <xref format="default" pageno="false" target="RFC8097"/> introduces an extended community for use in iBGP and selected eBGP scenarios, providing normative guidance on implementations' behavior if support for this feature is explicitly configured.
+      <xref format="default" pageno="false" target="RFC8097"/> introduces an extended community for use in iBGP and selected eBGP scenarios, providing normative guidance on implementations' behavior if and only if support for this feature is explicitly configured.
       This document does not provide normative guidance regarding implementation behavavior, i.e., regarding the support for the extended community for signalling validation state described in  <xref format="default" pageno="false" target="RFC8097"/>.
       Instead, guidance in this document is normative regarding operators' use of this feature.
     </t>

--- a/draft-ietf-sidrops-avoid-rpki-state-in-bgp.xml
+++ b/draft-ietf-sidrops-avoid-rpki-state-in-bgp.xml
@@ -12,6 +12,7 @@
    xmlns:xi="http://www.w3.org/2001/XInclude"
    category="bcp"
    consensus="true"
+   updates="8097"
    submissionType="IETF"
    docName="draft-ietf-sidrops-avoid-rpki-state-in-bgp-09"
    ipr="trust200902">


### PR DESCRIPTION
This PR clarifies the relationship between 8097 and this document as remarked by Mahesh Jethanandani and Ketan Talaulikar in their DISCUSS positions. It clarifies that 8097 gives implementation guidance (implementation behavior), explicitly requiring configuration, while this document provides guidance on configuration.

Furthermore, this PR introduces an UPDATES for 8097, clarifying that the described deployment scenarios are possible, but `<bcp14>NOT RECOMMENDED</bcp14>`, as the deployment scenarios in 8097 do not carry any normative language as of now. It further introduces normative text w.r.t. when operators `<bcp14>MAY</bcp14>` opt to implement the deployment scenarios.