### PR TITLE
Tf 2026 06 04 aspa spl ref

### DIFF
--- a/draft-ietf-sidrops-avoid-rpki-state-in-bgp.xml
+++ b/draft-ietf-sidrops-avoid-rpki-state-in-bgp.xml
@@ -351,7 +351,7 @@ https://mailarchive.ietf.org/arch/msg/sidrops/YV1WfoxQNiwfOjtKIY1d6YJjRxM/
         Reduction of memory consumption on customer/peer facing PE routers (less BGP communities == less memory pressure).
       </li>
       <li>
-        No effect on the age of a BGP route when a ROA or ASPA <xref target="I-D.ietf-sidrops-aspa-profile"/> is issued or revoked.
+        No effect on the age of a BGP route when a ROA or ASPA is issued or revoked.
       </li>
       <li>
         Avoids having to resend, e.g., more than 500,000 BGP routes towards BGP neighbors (for the own customer cone towards peers and providers, for the full table towards customers) if the RPKI cache crashes and RTR sessions are terminated, or if flaps in validation are caused by other events.

--- a/draft-ietf-sidrops-avoid-rpki-state-in-bgp.xml
+++ b/draft-ietf-sidrops-avoid-rpki-state-in-bgp.xml
@@ -263,7 +263,7 @@ https://mailarchive.ietf.org/arch/msg/sidrops/YV1WfoxQNiwfOjtKIY1d6YJjRxM/
       <t>
         In the case of BGP Prefix Origin Validation (<xref target="RFC6811"/>), for each change in the validation state of a route, an Autonomous System (AS) in which the local routing policy sets a BGP Community based on the validation state, routers would need to send BGP UPDATE messages for more than half of the global Internet routing table if the validation state changes to <tt>NotFound</tt>.
         The same, reversed case, would be true for every new ROA created by the address space holders, whereas a new BGP UPDATE would be generated, as the validation state would change to <tt>Valid</tt>.
-        Similar scaling concerns apply to other RPKI-derived validation mechanisms, such as ASPA verification (<xref target="I-D.ietf-sidrops-aspa-verification"/>) and SPL Verification (<xref target="I-D.ietf-sidrops-spl-verification"/>).
+        Similar scaling concerns apply to other RPKI-derived validation mechanisms, as, for example, ASPA verification (<xref target="I-D.ietf-sidrops-aspa-verification"/>).
       </t>
       <t>
         Furthermore, adding additional attributes to routes increases their size and memory consumption in the Routing Information Base of BGP routers.
@@ -441,7 +441,6 @@ https://mailarchive.ietf.org/arch/msg/sidrops/YV1WfoxQNiwfOjtKIY1d6YJjRxM/
     <xi:include href="https://bib.ietf.org/public/rfc/bibxml/reference.RFC.9582.xml"/>
     <xi:include href="https://bib.ietf.org/public/rfc/bibxml3/reference.I-D.ietf-sidrops-aspa-profile.xml"/>
     <xi:include href="https://bib.ietf.org/public/rfc/bibxml3/reference.I-D.ietf-sidrops-aspa-verification.xml"/>
-    <xi:include href="https://bib.ietf.org/public/rfc/bibxml3/reference.I-D.ietf-sidrops-spl-verification.xml"/>
 
     <reference anchor="How-to-break" target="https://cds.cern.ch/record/2805326">
       <front>


### PR DESCRIPTION
This PR introduces changes addressing Ketan Talaulikar's comment regarding the normative nature of the ASPA / SPL references. It removes one instance of normative referencing, and clarifies that the second instance is, similar to the use in the introduction, an illustrative example.